### PR TITLE
Use GitHub Actions cache for buildx

### DIFF
--- a/docker-multiarch-build-push/action.yml
+++ b/docker-multiarch-build-push/action.yml
@@ -59,14 +59,6 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
-    - name: Set up Docker layer caching
-      uses: actions/cache@v3
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ inputs.cache-key }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-${{ inputs.cache-key }}-
-
     - name: Build and push image
       id: build-and-push
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
@@ -79,8 +71,8 @@ runs:
         pull: ${{ inputs.pull }}
         push: ${{ inputs.push }}
         tags: ${{ inputs.tags }}
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Split branch name
       env:
@@ -120,13 +112,3 @@ runs:
       # against the sigstore community Fulcio instance.
       shell: bash
       run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
-
-    # Temp fix
-    # https://github.com/docker/build-push-action/issues/252
-    # https://github.com/moby/buildkit/issues/1896
-    # https://github.com/docker/buildx/pull/535
-    - name: Move cache
-      shell: bash
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
Replaces the previous workaround from before the GHA cache type was implemented