### PR TITLE
Add toggle for fail on severe CVE

### DIFF
--- a/docker-multiarch-build-push/action.yml
+++ b/docker-multiarch-build-push/action.yml
@@ -101,13 +101,13 @@ runs:
 
     - name: Fail if scan has CRITICAL or HIGH vulnerabilities
       uses: aquasecurity/trivy-action@91713af97dc80187565512baba96e4364e983601  # 0.16.0
+      if: ${{ inputs.fail_on_high_severity_cve }}
       with:
         image-ref: ${{ steps.split.outputs.TAG }}
         format: table
         exit-code: '1'
         severity: 'CRITICAL,HIGH'
         ignore-unfixed: true
-      if: ${{ inputs.fail_on_high_severity_cve }}
 
     # Sign the resulting Docker image digest except on PRs.
     # This will only write to the public Rekor transparency log when the Docker

--- a/docker-multiarch-build-push/action.yml
+++ b/docker-multiarch-build-push/action.yml
@@ -31,6 +31,9 @@ inputs:
   tags:
     description: List of tags
     required: false
+  fail_on_high_severity_cve:
+    description: If true, build will fail if any high or critical CVEs are found during trivy scan.
+    default: true
   sign_image:
     description: If true cosign is used to sign the image
     required: false
@@ -104,6 +107,7 @@ runs:
         exit-code: '1'
         severity: 'CRITICAL,HIGH'
         ignore-unfixed: true
+      if: ${{ inputs.fail_on_high_severity_cve }}
 
     # Sign the resulting Docker image digest except on PRs.
     # This will only write to the public Rekor transparency log when the Docker

--- a/docker-multiarch-build-push/action.yml
+++ b/docker-multiarch-build-push/action.yml
@@ -32,8 +32,9 @@ inputs:
     description: List of tags
     required: false
   fail_on_high_severity_cve:
-    description: If true, build will fail if any high or critical CVEs are found during trivy scan.
-    default: true
+    description: If true build will fail if any high or critical CVEs are found during trivy scan.
+    required: false
+    default: 'true'
   sign_image:
     description: If true cosign is used to sign the image
     required: false
@@ -101,7 +102,7 @@ runs:
 
     - name: Fail if scan has CRITICAL or HIGH vulnerabilities
       uses: aquasecurity/trivy-action@91713af97dc80187565512baba96e4364e983601  # 0.16.0
-      if: ${{ inputs.fail_on_high_severity_cve }}
+      if: ${{ inputs.fail_on_high_severity_cve == 'true' }}
       with:
         image-ref: ${{ steps.split.outputs.TAG }}
         format: table


### PR DESCRIPTION
For testing purposes we might sometimes want to build images despite scan results.