### PR TITLE
Use Trivy DB mirror to avoid rate-limit issues

### DIFF
--- a/.github/workflows/mirror-trivy-db.yml
+++ b/.github/workflows/mirror-trivy-db.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
   # Run nightly
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 */6 * * *'
 
 jobs:
   mirror_trivy_db:

--- a/docker-multiarch-build-push/action.yml
+++ b/docker-multiarch-build-push/action.yml
@@ -35,9 +35,6 @@ inputs:
   tags:
     description: List of tags
     required: false
-  github-token:
-    description: The GitHub token to use with Trivy to download the DB
-    required: false
 runs:
   using: composite
   steps:
@@ -95,7 +92,7 @@ runs:
         format: sarif
         output: trivy-results.sarif
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token || '' }}
+        TRIVY_DB_REPOSITORY: ghcr.io/azimuth-cloud/trivy-db:2
 
     - name: Determine commit SHA of checkout
       id: rev-parse
@@ -154,7 +151,7 @@ runs:
         severity: 'CRITICAL'
         ignore-unfixed: true
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token || '' }}
+        TRIVY_DB_REPOSITORY: ghcr.io/azimuth-cloud/trivy-db:2
 
     # Sign the resulting Docker image digest except on PRs.
     # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
See https://github.com/aquasecurity/trivy-action/issues/389