### PR TITLE
Reinstate Trivy DB mirror

### DIFF
--- a/.github/workflows/mirror-trivy-db.yml
+++ b/.github/workflows/mirror-trivy-db.yml
@@ -1,0 +1,31 @@
+# This workflow mirrors the Trivy DB into the azimuth-cloud namespace
+#
+# This is required, at least for now, to avoid rate-limit errors when using trivy-action
+# See https://github.com/aquasecurity/trivy-action/issues/389
+# N.B. none of the mitigations proposed there appear to fully fix the issue
+
+name: Mirror Trivy DB
+
+on:
+  # Allow manual executions
+  workflow_dispatch:
+  # Run nightly
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  mirror_trivy_db:
+    name: Mirror the latest Trivy DB image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Install ORAS
+        uses: oras-project/setup-oras@v1
+
+      - name: Log in to ghcr.io using ORAS
+        run: oras login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+
+      - name: Mirror Trivy DB using ORAS
+        run: oras cp ghcr.io/aquasecurity/trivy-db:2 ghcr.io/azimuth-cloud/trivy-db:2

--- a/docker-multiarch-build-push/action.yml
+++ b/docker-multiarch-build-push/action.yml
@@ -150,6 +150,8 @@ runs:
         exit-code: '1'
         severity: 'CRITICAL'
         ignore-unfixed: true
+      env:
+        TRIVY_DB_REPOSITORY: ghcr.io/azimuth-cloud/trivy-db:2
 
     # Sign the resulting Docker image digest except on PRs.
     # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
It seems that #24 didn't completely fix the DB rate limits issue as we're still seeing it in some workflows. This PR restores the Trivy DB mirror settings until the issue is properly resolved upstream.