### PR TITLE
Bump second trivy-action to 0.34.2

### DIFF
--- a/docker-multiarch-build-push/action.yml
+++ b/docker-multiarch-build-push/action.yml
@@ -148,7 +148,7 @@ runs:
         }}
 
     - name: Fail if scan has CRITICAL vulnerabilities
-      uses: aquasecurity/trivy-action@0.29.0
+      uses: aquasecurity/trivy-action@0.34.2
       with:
         image-ref: ${{ steps.split.outputs.image-ref }}
         format: table


### PR DESCRIPTION
I missed an instance of the aquasecurity/trivy-action in review of #28. This change completes that update