### PR TITLE
Bump dependencies in docker-multiarch-build-push

### DIFF
--- a/docker-multiarch-build-push/action.yml
+++ b/docker-multiarch-build-push/action.yml
@@ -60,11 +60,11 @@ runs:
     # multi-platform images and export cache
     # https://github.com/docker/setup-buildx-action
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build and push image
       id: build-and-push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         build-args: ${{ inputs.build-args }}
         context: ${{ inputs.context }}


### PR DESCRIPTION
Seeing segfaults during linux/arm64 builds so updating to latest docker/build-push-action and docker/setup-buildx-action to try and rule these out.