### PR TITLE
Images without a repository are library images

### DIFF
--- a/k8s-extract-images/k8s-extract-images.py
+++ b/k8s-extract-images/k8s-extract-images.py
@@ -184,6 +184,9 @@ def verify_image(image):
     # docker.io is not itself a valid Docker v2 registry
     if registry == "docker.io":
         registry = "registry-1.docker.io"
+        # Top-level docker.io repositories actually resolve to library/repository
+        if "/" not in repository:
+            repository = f"library/{repository}"
 
     manifest_url = f"https://{registry}/v2/{repository}/manifests/{tag}"
     # Attempt to get the manifest

--- a/k8s-extract-images/k8s-extract-images.py
+++ b/k8s-extract-images/k8s-extract-images.py
@@ -181,6 +181,10 @@ def verify_image(image):
     repository, tag = image.rsplit(":", maxsplit = 1)
     registry, repository = repository.split("/", maxsplit = 1)
 
+    # docker.io is not itself a valid Docker v2 registry
+    if registry == "docker.io":
+        registry = "registry-1.docker.io"
+
     manifest_url = f"https://{registry}/v2/{repository}/manifests/{tag}"
     # Attempt to get the manifest
     response = requests.get(manifest_url, headers = REGISTRY_HEADERS)


### PR DESCRIPTION
Revert "Don't rename docker.io to registry-1"

docker.io top-level images (ones that don't have a repository) are published by dockerhub and are in the library namespace of registry-1.docker.io, despite being able to be pulled from docker.io/{image}:{tag}.

This matters for validating images, not for pulling/syncing, so validate the image at docker.io/library/{image}:{tag} but still output the image at docker.io/{image}:{tag}.